### PR TITLE
Update run_server.bat to work in directories with spaces in them

### DIFF
--- a/run_server.bat
+++ b/run_server.bat
@@ -1,1 +1,1 @@
-powershell -Command "Start-Process powershell '-NoProfile -ExecutionPolicy Bypass -File %cd%\stealth.ps1' -Verb RunAs"
+powershell -Command "Start-Process powershell '-NoProfile -ExecutionPolicy Bypass -File ""%cd%\stealth.ps1""' -Verb RunAs"


### PR DESCRIPTION
Just a quick easy fix, the Powershell window was immediately closing on my setup, because I'd stuck spaces in the install directory. Added escaped quotes around %cd%.